### PR TITLE
adding the Sonatype OSSRH to the pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,4 +69,25 @@
 		<module>client</module>
 	</modules>
 
+	<!-- =================================================================== -->
+	<!--   REPOSITORIES                                                    -->
+	<!-- =================================================================== -->
+
+	<!-- Sonatype OSSRH where LDP4j snapshots are deployed -->
+	<repositories>
+	        <repository>
+	            <id>oss-snapshots</id>
+	            <url>
+	                https://oss.sonatype.org/content/groups/public
+	            </url>
+	            <snapshots>
+	                <enabled>true</enabled>
+	                <updatePolicy>daily</updatePolicy>
+	            </snapshots>
+	            <releases>
+	                <enabled>false</enabled>
+	            </releases>
+	        </repository>
+	</repositories>
+
 </project>


### PR DESCRIPTION
Shall we add the snapshot repo to the pom file so that users don't have to build the sources of LDP4j (or was it omitted for some special reason) ?
